### PR TITLE
Fix tracker to persist entries and read calendar data

### DIFF
--- a/NoCaTra/ViewModels/CalendarViewModel.swift
+++ b/NoCaTra/ViewModels/CalendarViewModel.swift
@@ -31,4 +31,18 @@ class CalendarViewModel: ObservableObject {
             entry.content = newContent
         }
     }
+
+    /// Update an entry's first rating value.
+    func update(entry: EntryModule, ratingOne: Int) {
+        if entry.ratingOne != ratingOne {
+            entry.ratingOne = ratingOne
+        }
+    }
+
+    /// Update an entry's second rating value.
+    func update(entry: EntryModule, ratingTwo: Int) {
+        if entry.ratingTwo != ratingTwo {
+            entry.ratingTwo = ratingTwo
+        }
+    }
 }

--- a/NoCaTra/Views/CalendarTabView/CalendarDailyInfoView.swift
+++ b/NoCaTra/Views/CalendarTabView/CalendarDailyInfoView.swift
@@ -20,10 +20,11 @@ struct CalendarDailyInfoView: View {
     }()
     
     var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            Text(dateFormatter.string(from: selectedDate))
-                .font(.headline)
-                .padding(.horizontal)
+        ScrollView {
+            VStack(alignment: .leading, spacing: 12) {
+                Text(dateFormatter.string(from: selectedDate))
+                    .font(.headline)
+                    .padding(.horizontal)
             
             Divider()
             
@@ -40,20 +41,14 @@ struct CalendarDailyInfoView: View {
                         .italic()
                 } else {
                     ForEach(entriesForDate) { entry in
-                        VStack(alignment: .leading, spacing: 4) {
-                            Text(entry.category.rawValue.capitalized)
-                                .font(.caption)
-                                .foregroundColor(.gray)
-
+                        GroupBox(label: Text(entry.category.rawValue.capitalized)) {
                             switch entry.contentType {
                             case .diary, .plan:
                                 TextField("Entry content", text: Binding(
                                     get: { entry.content },
-                                    set: { newValue in
-                                        viewModel.update(entry: entry, with: newValue)
-                                    }
+                                    set: { viewModel.update(entry: entry, with: $0) }
                                 ))
-                                .textFieldStyle(RoundedBorderTextFieldStyle())
+                                .textFieldStyle(.roundedBorder)
 
                             case .rating:
                                 HStack(spacing: 20) {
@@ -92,12 +87,10 @@ struct CalendarDailyInfoView: View {
                 }
             }
             .padding(.horizontal)
-            
-            Spacer()
         }
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(Color(white: 0.95))
     }
+    .background(Color(white: 0.95))
 }
 
 #Preview {

--- a/NoCaTra/Views/CalendarTabView/CalendarDailyInfoView.swift
+++ b/NoCaTra/Views/CalendarTabView/CalendarDailyInfoView.swift
@@ -6,10 +6,12 @@
 //
 
 import SwiftUI
+import SwiftData
 
 struct CalendarDailyInfoView: View {
     let selectedDate: Date
     @ObservedObject var viewModel: CalendarViewModel
+    @Environment(\.modelContext) private var context
     
     private let dateFormatter: DateFormatter = {
         let formatter = DateFormatter()
@@ -30,7 +32,7 @@ struct CalendarDailyInfoView: View {
                     .font(.subheadline)
                     .foregroundColor(.secondary)
                 
-                let entriesForDate = viewModel.entries(for: selectedDate)
+                let entriesForDate = viewModel.entries(for: selectedDate, context: context)
 
                 if entriesForDate.isEmpty {
                     Text("No entries for today")

--- a/NoCaTra/Views/CalendarTabView/CalendarDailyInfoView.swift
+++ b/NoCaTra/Views/CalendarTabView/CalendarDailyInfoView.swift
@@ -44,13 +44,48 @@ struct CalendarDailyInfoView: View {
                             Text(entry.category.rawValue.capitalized)
                                 .font(.caption)
                                 .foregroundColor(.gray)
-                            TextField("Entry content", text: Binding(
-                                get: { entry.content },
-                                set: { newValue in
-                                    viewModel.update(entry: entry, with: newValue)
+
+                            switch entry.contentType {
+                            case .diary, .plan:
+                                TextField("Entry content", text: Binding(
+                                    get: { entry.content },
+                                    set: { newValue in
+                                        viewModel.update(entry: entry, with: newValue)
+                                    }
+                                ))
+                                .textFieldStyle(RoundedBorderTextFieldStyle())
+
+                            case .rating:
+                                HStack(spacing: 20) {
+                                    VStack {
+                                        Text("Healthiness")
+                                            .font(.caption)
+                                        Picker("Rating One", selection: Binding(
+                                            get: { entry.ratingOne ?? 5 },
+                                            set: { viewModel.update(entry: entry, ratingOne: $0) }
+                                        )) {
+                                            ForEach(1...10, id: \.self) { num in
+                                                Text("\(num)")
+                                            }
+                                        }
+                                        .pickerStyle(.menu)
+                                    }
+
+                                    VStack {
+                                        Text("Happiness")
+                                            .font(.caption)
+                                        Picker("Rating Two", selection: Binding(
+                                            get: { entry.ratingTwo ?? 5 },
+                                            set: { viewModel.update(entry: entry, ratingTwo: $0) }
+                                        )) {
+                                            ForEach(1...10, id: \.self) { num in
+                                                Text("\(num)")
+                                            }
+                                        }
+                                        .pickerStyle(.menu)
+                                    }
                                 }
-                            ))
-                            .textFieldStyle(RoundedBorderTextFieldStyle())
+                            }
                         }
                         .padding(.vertical, 4)
                     }

--- a/NoCaTra/Views/CalendarTabView/CalendarTabView.swift
+++ b/NoCaTra/Views/CalendarTabView/CalendarTabView.swift
@@ -12,10 +12,12 @@ struct CalendarTabView: View {
     @StateObject private var calendarViewModel = CalendarViewModel()
     
     var body: some View {
-        VStack(spacing: 0) {
-            CalendarHeaderView()
-            CalendarView(selectedDate: $selectedDate, calendarViewModel: calendarViewModel)
-            CalendarDailyInfoView(selectedDate: selectedDate, viewModel: calendarViewModel)
+        ScrollView {
+            VStack(spacing: 0) {
+                CalendarHeaderView()
+                CalendarView(selectedDate: $selectedDate, calendarViewModel: calendarViewModel)
+                CalendarDailyInfoView(selectedDate: selectedDate, viewModel: calendarViewModel)
+            }
         }
     }
 }

--- a/NoCaTra/Views/CalendarTabView/CalendarView.swift
+++ b/NoCaTra/Views/CalendarTabView/CalendarView.swift
@@ -6,15 +6,10 @@
 //
 
 import SwiftUI
-struct IdentifiableDate: Identifiable {
-    let id = UUID()
-    let date: Date
-}
 
 struct CalendarView: View {
     @Binding var selectedDate: Date
     @State private var displayedMonth = Date()
-    @State private var selectedDateForSheet: IdentifiableDate? = nil
     @ObservedObject var calendarViewModel: CalendarViewModel
     private let calendar = Calendar.current
     private let weekdaySymbols = Calendar.current.veryShortWeekdaySymbols
@@ -58,7 +53,6 @@ struct CalendarView: View {
                                isToday: calendar.isDateInToday(date))
                             .onTapGesture {
                                 selectedDate = date
-                                selectedDateForSheet = IdentifiableDate(date: date)
                             }
                     } else {
                         Color.clear
@@ -68,9 +62,6 @@ struct CalendarView: View {
             }
         }
         .padding()
-        .sheet(item: $selectedDateForSheet) { identifiableDate in
-            CalendarDailyInfoView(selectedDate: identifiableDate.date, viewModel: calendarViewModel)
-        }
     }
     
     private var monthYearString: String {

--- a/NoCaTra/Views/TrackerView.swift
+++ b/NoCaTra/Views/TrackerView.swift
@@ -90,17 +90,26 @@ public struct TrackerView: View {
         
         let contentBinding = Binding(
             get: { contentState[entry.id] ?? entry.content },
-            set: { contentState[entry.id] = $0 }
+            set: { newValue in
+                contentState[entry.id] = newValue
+                entry.content = newValue
+            }
         )
         
         let ratingOneBinding = Binding(
             get: { ratingOneState[entry.id] ?? entry.ratingOne },
-            set: { ratingOneState[entry.id] = $0 }
+            set: { newValue in
+                ratingOneState[entry.id] = newValue
+                entry.ratingOne = newValue
+            }
         )
         
         let ratingTwoBinding = Binding(
             get: { ratingTwoState[entry.id] ?? entry.ratingTwo },
-            set: { ratingTwoState[entry.id] = $0 }
+            set: { newValue in
+                ratingTwoState[entry.id] = newValue
+                entry.ratingTwo = newValue
+            }
         )
 
         let isLockedBinding = Binding(


### PR DESCRIPTION
## Summary
- update TrackerView bindings to write directly to `EntryModule`
- fetch calendar entries from SwiftData in CalendarViewModel
- have CalendarDailyInfoView request entries from the model context

## Testing
- `swift --version`
- `swift test -l` *(fails: Could not find Package.swift)*
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68500915bf7c832cb9b2d4939be9ed3a