### PR TITLE
Sort calendar modules by category

### DIFF
--- a/NoCaTra/Components/EntryModule/EntryModuleMiddleView.swift
+++ b/NoCaTra/Components/EntryModule/EntryModuleMiddleView.swift
@@ -17,6 +17,7 @@ struct EntryModuleMiddleView: View {
     @Binding var content: String
     @Binding var ratingOne: Int?
     @Binding var ratingTwo: Int?
+    var previousContent: String? = nil
     
     var body: some View {
         VStack(spacing: 12) {
@@ -29,33 +30,41 @@ struct EntryModuleMiddleView: View {
                     .cornerRadius(8)
                 
             case .rating:
-                HStack(spacing: 20) {
-                    VStack {
-                        Text("Healthiness")
-                            .font(.caption)
-                        Picker("Rating One", selection: Binding(
-                            get: { ratingOne ?? 5 },
-                            set: { ratingOne = $0 }
-                        )) {
-                            ForEach(1...10, id: \.self) { num in
-                                Text("\(num)")
-                            }
-                        }
-                        .pickerStyle(.menu)
+                VStack(alignment: .leading, spacing: 8) {
+                    if let text = previousContent, !text.isEmpty {
+                        Text(text)
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                            .frame(maxWidth: .infinity, alignment: .leading)
                     }
-                    
-                    VStack {
-                        Text("Happiness")
-                            .font(.caption)
-                        Picker("Rating Two", selection: Binding(
-                            get: { ratingTwo ?? 5 },
-                            set: { ratingTwo = $0 }
-                        )) {
-                            ForEach(1...10, id: \.self) { num in
-                                Text("\(num)")
+                    HStack(spacing: 20) {
+                        VStack {
+                            Text("Healthiness")
+                                .font(.caption)
+                            Picker("Rating One", selection: Binding(
+                                get: { ratingOne ?? 5 },
+                                set: { ratingOne = $0 }
+                            )) {
+                                ForEach(1...10, id: \.self) { num in
+                                    Text("\(num)")
+                                }
                             }
+                            .pickerStyle(.menu)
                         }
-                        .pickerStyle(.menu)
+
+                        VStack {
+                            Text("Happiness")
+                                .font(.caption)
+                            Picker("Rating Two", selection: Binding(
+                                get: { ratingTwo ?? 5 },
+                                set: { ratingTwo = $0 }
+                            )) {
+                                ForEach(1...10, id: \.self) { num in
+                                    Text("\(num)")
+                                }
+                            }
+                            .pickerStyle(.menu)
+                        }
                     }
                 }
                 .padding(.horizontal)
@@ -85,7 +94,8 @@ struct EntryModuleMiddleView: View {
                     contentType: .rating,
                     content: $text,
                     ratingOne: $ratingOne,
-                    ratingTwo: $ratingTwo
+                    ratingTwo: $ratingTwo,
+                    previousContent: "Yesterday's diary"
                 )
             }
             .padding()

--- a/NoCaTra/Components/EntryModule/EntryModuleView.swift
+++ b/NoCaTra/Components/EntryModule/EntryModuleView.swift
@@ -42,26 +42,30 @@ struct EntryModuleView: View {
         }
     }
     
-    private var caption: String {
+    private var caption: Text {
+        if !canStartSession && !isOpen {
+            return Text("Completed, but you can still edit in the calendar. Don't worry if you didn't get everything")
+        }
+
         switch (module.category, module.contentType) {
         case (.food, .diary):
-            return "Record what you ate today"
+            return Text("Track your meals from ") + Text("yesterday").bold()
         case (.food, .plan):
-            return "Plan your meals for today"
+            return Text("Plan your meals for today")
         case (.food, .rating):
-            return "Rate your eating habits today"
+            return Text("Rate your meals from ") + Text("2 days ago").bold()
         case (.exercise, .diary):
-            return "Record your activities today"
+            return Text("Track your exercise from ") + Text("yesterday").bold()
         case (.exercise, .plan):
-            return "Plan your workouts for today"
+            return Text("Plan your workouts for today")
         case (.exercise, .rating):
-            return "Rate your exercise habits today"
+            return Text("Rate your exercise from ") + Text("2 days ago").bold()
         case (.mindfulness, .diary):
-            return "Record your mindfulness practice today"
+            return Text("Track your mindfulness practice from ") + Text("yesterday").bold()
         case (.mindfulness, .plan):
-            return "Plan your mindfulness activities for today"
+            return Text("Plan your mindfulness activities for today")
         case (.mindfulness, .rating):
-            return "Rate your mindfulness practice today"
+            return Text("Rate your mindfulness practice from ") + Text("2 days ago").bold()
         }
     }
     
@@ -113,7 +117,7 @@ struct EntryModuleView: View {
             }
             
             // Caption
-            Text(caption)
+            caption
                 .font(.caption)
                 .foregroundStyle(.secondary)
         }

--- a/NoCaTra/Components/EntryModule/EntryModuleView.swift
+++ b/NoCaTra/Components/EntryModule/EntryModuleView.swift
@@ -23,6 +23,7 @@ struct EntryModuleView: View {
     @Binding var ratingOne: Int?
     @Binding var ratingTwo: Int?
     @Binding var isLocked: Bool
+    var previousContent: String? = nil
     
     @State private var isSessionStarted = false
     @State private var sessionTimer: Timer? = nil
@@ -105,7 +106,8 @@ struct EntryModuleView: View {
                     contentType: module.contentType,
                     content: $content,
                     ratingOne: $ratingOne,
-                    ratingTwo: $ratingTwo
+                    ratingTwo: $ratingTwo,
+                    previousContent: previousContent
                 )
                     .transition(AnyTransition.move(edge: .top).combined(with: .opacity))
             }

--- a/NoCaTra/Utilities/EntryModuleSorting.swift
+++ b/NoCaTra/Utilities/EntryModuleSorting.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+extension Array where Element == EntryModule {
+    /// Sort `EntryModule` objects by category (food, exercise, mindfulness) and content type (diary, plan, rating).
+    func sortedByCategoryAndContent() -> [EntryModule] {
+        let categoryIndex: [EntryCategory: Int] = [
+            .food: 0,
+            .exercise: 1,
+            .mindfulness: 2
+        ]
+        let contentIndex: [EntryContentType: Int] = [
+            .diary: 0,
+            .plan: 1,
+            .rating: 2
+        ]
+
+        return self.sorted { lhs, rhs in
+            let lhsCat = categoryIndex[lhs.category] ?? 0
+            let rhsCat = categoryIndex[rhs.category] ?? 0
+            if lhsCat != rhsCat {
+                return lhsCat < rhsCat
+            }
+            let lhsContent = contentIndex[lhs.contentType] ?? 0
+            let rhsContent = contentIndex[rhs.contentType] ?? 0
+            return lhsContent < rhsContent
+        }
+    }
+}

--- a/NoCaTra/ViewModels/CalendarViewModel.swift
+++ b/NoCaTra/ViewModels/CalendarViewModel.swift
@@ -22,7 +22,9 @@ class CalendarViewModel: ObservableObject {
             }
         )
 
-        return (try? context.fetch(descriptor)) ?? []
+        let fetched = (try? context.fetch(descriptor)) ?? []
+
+        return fetched.sortedByCategoryAndContent()
     }
 
     /// Update an entry's content directly in the model.

--- a/NoCaTra/Views/TrackerView.swift
+++ b/NoCaTra/Views/TrackerView.swift
@@ -63,6 +63,20 @@ public struct TrackerView: View {
         return filtered.sortedByCategoryAndContent()
     }
 
+    /// Fetch the diary content from two days ago for the given category.
+    internal func diaryFromTwoDaysAgo(for category: EntryCategory) -> String? {
+        let calendar = Calendar.current
+        let today = calendar.startOfDay(for: Date())
+        let start = calendar.date(byAdding: .day, value: -2, to: today)!
+        let end = calendar.date(byAdding: .day, value: -1, to: today)!
+
+        return allEntries.first(where: { entry in
+            entry.category == category &&
+            entry.contentType == .diary &&
+            entry.date >= start && entry.date < end
+        })?.content
+    }
+
     public var body: some View {
         ScrollView {
             VStack(spacing: 12) {
@@ -75,7 +89,8 @@ public struct TrackerView: View {
                         content: contentBinding,
                         ratingOne: ratingOneBinding,
                         ratingTwo: ratingTwoBinding,
-                        isLocked: isLockedBinding
+                        isLocked: isLockedBinding,
+                        previousContent: entry.contentType == .rating ? diaryFromTwoDaysAgo(for: entry.category) : nil
                     )
                 }
             }

--- a/NoCaTra/Views/TrackerView.swift
+++ b/NoCaTra/Views/TrackerView.swift
@@ -29,11 +29,24 @@ public struct TrackerView: View {
     internal var todayEntries: [EntryModule] {
         let calendar = Calendar.current
         let today = calendar.startOfDay(for: Date())
+
         let tomorrow = calendar.date(byAdding: .day, value: 1, to: today)!
-        
-        return allEntries.filter { entry in
-            guard entry.date >= today && entry.date < tomorrow else { return false }
-            
+        let yesterday = calendar.date(byAdding: .day, value: -1, to: today)!
+        let twoDaysAgo = calendar.date(byAdding: .day, value: -2, to: today)!
+
+        let filtered = allEntries.filter { entry in
+            let dateRange: Range<Date>
+            switch entry.contentType {
+            case .plan:
+                dateRange = today..<tomorrow
+            case .diary:
+                dateRange = yesterday..<today
+            case .rating:
+                dateRange = twoDaysAgo..<yesterday
+            }
+
+            guard dateRange.contains(entry.date) else { return false }
+
             switch (entry.category, entry.contentType) {
             case (.food, .diary): return unlockableViewModel.unlockStates[0]
             case (.food, .plan): return unlockableViewModel.unlockStates[1]
@@ -46,6 +59,8 @@ public struct TrackerView: View {
             case (.mindfulness, .rating): return unlockableViewModel.unlockStates[8]
             }
         }
+
+        return filtered.sortedByCategoryAndContent()
     }
 
     public var body: some View {


### PR DESCRIPTION
## Summary
- add helper to sort entry modules by category and type
- use the helper in `CalendarViewModel` and `TrackerView`
- show diary modules from yesterday and rating modules from two days ago

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68503f9620b4832c9d7d00209d4328e6