### PR TITLE
Implement module streak tracking

### DIFF
--- a/NoCaTra/Components/EntryModule/EntryModuleView.swift
+++ b/NoCaTra/Components/EntryModule/EntryModuleView.swift
@@ -24,6 +24,7 @@ struct EntryModuleView: View {
     @Binding var ratingTwo: Int?
     @Binding var isLocked: Bool
     var previousContent: String? = nil
+    var streak: Int = 0
     
     @State private var isSessionStarted = false
     @State private var sessionTimer: Timer? = nil
@@ -120,6 +121,10 @@ struct EntryModuleView: View {
             caption
                 .font(.caption)
                 .foregroundStyle(.secondary)
+
+            Text("Streak: \(streak)")
+                .font(.caption2)
+                .foregroundStyle(.secondary)
         }
         .padding()
         .background(
@@ -134,6 +139,7 @@ struct EntryModuleView: View {
         isSessionStarted = true
         canStartSession = false
         timeRemaining = 300
+        module.isCompleted = false
         sessionTimer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { timer in
             if timeRemaining > 0 {
                 timeRemaining -= 1
@@ -143,6 +149,7 @@ struct EntryModuleView: View {
                     isOpen = false
                     isSessionStarted = false
                     timer.invalidate()
+                    module.isCompleted = true
                 }
             }
         }
@@ -153,5 +160,6 @@ struct EntryModuleView: View {
         sessionTimer = nil
         isOpen = false
         isSessionStarted = false
+        module.isCompleted = true
     }
 }

--- a/NoCaTra/Components/EntryModule/EntryModuleView.swift
+++ b/NoCaTra/Components/EntryModule/EntryModuleView.swift
@@ -30,6 +30,13 @@ struct EntryModuleView: View {
     @State private var sessionTimer: Timer? = nil
     @State private var canStartSession = true
     @State private var timeRemaining: Int = 300
+
+    private var canRate: Bool {
+        if module.contentType == .rating {
+            guard let text = previousContent, !text.isEmpty else { return false }
+        }
+        return true
+    }
     
     // MARK: - Computed Properties
     private var title: String {
@@ -74,6 +81,9 @@ struct EntryModuleView: View {
         if isOpen {
             return "Done"
         }
+        if !canRate {
+            return "Nothing to grade"
+        }
         if !canStartSession {
             return "Completed"
         }
@@ -85,8 +95,14 @@ struct EntryModuleView: View {
         VStack(spacing: 8) {
             // Header
             HStack {
-                Text(title)
-                    .font(.headline)
+                HStack(spacing: 4) {
+                    Text(title)
+                        .font(.headline)
+                    if streak > 0 {
+                        Text("🔥 \(streak)")
+                            .font(.subheadline)
+                    }
+                }
                 Spacer()
                 if isOpen {
                     Text("\(timeRemaining / 60):\(String(format: "%02d", timeRemaining % 60))")
@@ -102,7 +118,7 @@ struct EntryModuleView: View {
                         }
                     }
                 }
-                .disabled(!canStartSession && !isOpen)
+                .disabled((!canStartSession && !isOpen) || !canRate)
             }
             
             // Middle portion (only if open)
@@ -121,10 +137,7 @@ struct EntryModuleView: View {
             caption
                 .font(.caption)
                 .foregroundStyle(.secondary)
-
-            Text("Streak: \(streak)")
-                .font(.caption2)
-                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
         }
         .padding()
         .background(

--- a/NoCaTra/Views/TrackerView.swift
+++ b/NoCaTra/Views/TrackerView.swift
@@ -90,7 +90,8 @@ public struct TrackerView: View {
                         ratingOne: ratingOneBinding,
                         ratingTwo: ratingTwoBinding,
                         isLocked: isLockedBinding,
-                        previousContent: entry.contentType == .rating ? diaryFromTwoDaysAgo(for: entry.category) : nil
+                        previousContent: entry.contentType == .rating ? diaryFromTwoDaysAgo(for: entry.category) : nil,
+                        streak: streak(for: entry)
                     )
                 }
             }
@@ -158,5 +159,28 @@ public struct TrackerView: View {
             ratingOneState[entry.id] = ratingOneState[entry.id] ?? entry.ratingOne
             ratingTwoState[entry.id] = ratingTwoState[entry.id] ?? entry.ratingTwo
         }
+    }
+
+    internal func streak(for module: EntryModule) -> Int {
+        let calendar = Calendar.current
+        var currentDate = calendar.startOfDay(for: module.date)
+        var count = 0
+
+        while true {
+            guard let match = allEntries.first(where: { entry in
+                entry.category == module.category &&
+                entry.contentType == module.contentType &&
+                calendar.isDate(entry.date, inSameDayAs: currentDate)
+            }) else { break }
+
+            guard match.isCompleted else { break }
+
+            count += 1
+
+            guard let previous = calendar.date(byAdding: .day, value: -1, to: currentDate) else { break }
+            currentDate = previous
+        }
+
+        return count
     }
 }


### PR DESCRIPTION
## Summary
- add streak counter to `EntryModuleView`
- update session logic to mark entries as completed
- compute streak counts in `TrackerView`
- display streak info on tracker modules

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68520dfe9f34832c846030f1979c25fc