### PR TITLE
Improve calendar appearance

### DIFF
--- a/NoCaTra/NoCaTraApp.swift
+++ b/NoCaTra/NoCaTraApp.swift
@@ -8,12 +8,16 @@
 import SwiftUI
 import SwiftData
 
+/// Global color theme for the app
+fileprivate let appAccent = ColorTheme.accent
+
 @main
 struct NoCaTraApp: App {
     var body: some Scene {
         WindowGroup {
             ContentView()
                 .modelContainer(for: EntryModule.self)
+                .tint(appAccent)
                 .onAppear {
                     if checkFirstEver() {
                         FirstEver.setStartDate()

--- a/NoCaTra/Views/CalendarTabView/CalendarDailyInfoView.swift
+++ b/NoCaTra/Views/CalendarTabView/CalendarDailyInfoView.swift
@@ -41,7 +41,7 @@ struct CalendarDailyInfoView: View {
                             .italic()
                     } else {
                         ForEach(entriesForDate) { entry in
-                            GroupBox(label: Text(entry.category.rawValue.capitalized)) {
+                            GroupBox(label: Text(entry.category.rawValue.capitalized).foregroundColor(ColorTheme.accent)) {
                                 switch entry.contentType {
                                 case .diary, .plan:
                                     TextField("Entry content", text: Binding(
@@ -90,6 +90,6 @@ struct CalendarDailyInfoView: View {
             }
             .frame(maxWidth: .infinity, alignment: .leading)
         }
-        .background(Color(white: 0.95))
+        .background(ColorTheme.background)
     }
 }

--- a/NoCaTra/Views/CalendarTabView/CalendarHeaderView.swift
+++ b/NoCaTra/Views/CalendarTabView/CalendarHeaderView.swift
@@ -12,7 +12,8 @@ struct CalendarHeaderView: View {
         Text("Tracker Calendar")
             .font(.title2)
             .fontWeight(.bold)
-            .padding()
+            .foregroundColor(ColorTheme.accent)
+            .padding(.vertical, 8)
     }
 }
 

--- a/NoCaTra/Views/CalendarTabView/CalendarTabView.swift
+++ b/NoCaTra/Views/CalendarTabView/CalendarTabView.swift
@@ -19,6 +19,7 @@ struct CalendarTabView: View {
                 CalendarDailyInfoView(selectedDate: selectedDate, viewModel: calendarViewModel)
             }
         }
+        .background(ColorTheme.background.ignoresSafeArea())
     }
 }
 

--- a/NoCaTra/Views/CalendarTabView/CalendarView.swift
+++ b/NoCaTra/Views/CalendarTabView/CalendarView.swift
@@ -20,7 +20,7 @@ struct CalendarView: View {
             HStack {
                 Button(action: previousMonth) {
                     Image(systemName: "chevron.left")
-                        .foregroundColor(.blue)
+                        .foregroundColor(ColorTheme.accent)
                 }
                 
                 Text(monthYearString)
@@ -30,7 +30,7 @@ struct CalendarView: View {
                 
                 Button(action: nextMonth) {
                     Image(systemName: "chevron.right")
-                        .foregroundColor(.blue)
+                        .foregroundColor(ColorTheme.accent)
                 }
             }
             .padding(.horizontal)
@@ -62,6 +62,12 @@ struct CalendarView: View {
             }
         }
         .padding()
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .fill(ColorTheme.background)
+                .shadow(color: .black.opacity(0.1), radius: 2, x: 0, y: 1)
+        )
+        .padding(.horizontal)
     }
     
     private var monthYearString: String {
@@ -116,25 +122,32 @@ struct DayView: View {
     let isSelected: Bool
     let isToday: Bool
     private let calendar = Calendar.current
-    
+
     var body: some View {
         Text("\(calendar.component(.day, from: date))")
             .frame(maxWidth: .infinity)
             .aspectRatio(1, contentMode: .fill)
             .background(background)
+            .foregroundColor(textColor)
             .clipShape(Circle())
     }
-    
+
     private var background: some View {
         Group {
             if isSelected {
                 Circle()
-                    .fill(Color.blue)
+                    .fill(ColorTheme.accent)
             } else if isToday {
                 Circle()
-                    .stroke(Color.blue, lineWidth: 1)
+                    .stroke(ColorTheme.accent, lineWidth: 1)
             }
         }
+    }
+
+    private var textColor: Color {
+        if isSelected { return .white }
+        if calendar.isDateInWeekend(date) { return .secondary }
+        return .primary
     }
 }
 


### PR DESCRIPTION
## Summary
- apply global tint to the app
- color the calendar header and icons with the accent color
- style the calendar grid with rounded background
- improve day cells with accent highlight and weekend text color
- tint group boxes in the daily info section

## Testing
- `swift test -t NoCaTraTests --disable-sandbox` *(fails: Unknown option)*

------
https://chatgpt.com/codex/tasks/task_e_685213780c9c832c906ff9ff61204163