### PR TITLE
Improve calendar clarity

### DIFF
--- a/NoCaTra/Views/CalendarTabView/CalendarDailyInfoView.swift
+++ b/NoCaTra/Views/CalendarTabView/CalendarDailyInfoView.swift
@@ -41,7 +41,7 @@ struct CalendarDailyInfoView: View {
                             .italic()
                     } else {
                         ForEach(entriesForDate) { entry in
-                            GroupBox(label: Text(entry.category.rawValue.capitalized)) {
+                            GroupBox {
                                 switch entry.contentType {
                                 case .diary, .plan:
                                     TextField("Entry content", text: Binding(
@@ -49,7 +49,7 @@ struct CalendarDailyInfoView: View {
                                         set: { viewModel.update(entry: entry, with: $0) }
                                     ))
                                     .textFieldStyle(.roundedBorder)
-    
+
                                 case .rating:
                                     HStack(spacing: 20) {
                                         VStack {
@@ -80,6 +80,14 @@ struct CalendarDailyInfoView: View {
                                             .pickerStyle(.menu)
                                         }
                                     }
+                                }
+                            } label: {
+                                HStack {
+                                    Text(entry.category.rawValue.capitalized)
+                                    Spacer()
+                                    Text(entry.contentType.rawValue.capitalized)
+                                        .font(.caption)
+                                        .foregroundColor(.secondary)
                                 }
                             }
                             .padding(.vertical, 4)

--- a/README.md
+++ b/README.md
@@ -9,4 +9,4 @@ Goals:
 Next changes:
 - Make an unlockable section?
 - Change the calendar to make it more clear
-- Make the calendar say what is diary vs plan
+- ~~Make the calendar say what is diary vs plan~~ (done)


### PR DESCRIPTION
## Summary
- show entry category and type in the calendar
- mark diary vs plan improvement as done in README

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6852172ae738832c9cb3cb8a9eb95e25