### PR TITLE
Use ColorTheme in UI

### DIFF
--- a/NoCaTra/Components/EntryModule/EntryModuleMiddleView.swift
+++ b/NoCaTra/Components/EntryModule/EntryModuleMiddleView.swift
@@ -26,7 +26,7 @@ struct EntryModuleMiddleView: View {
                 TextEditor(text: $content)
                     .frame(height: 100)
                     .padding(8)
-                    .background(.gray.opacity(0.1))
+                    .background(ColorTheme.inputBorder.opacity(0.1))
                     .cornerRadius(8)
                 
             case .rating:
@@ -34,7 +34,7 @@ struct EntryModuleMiddleView: View {
                     if let text = previousContent, !text.isEmpty {
                         Text(text)
                             .font(.subheadline)
-                            .foregroundStyle(.secondary)
+                            .foregroundStyle(ColorTheme.secondaryText)
                             .frame(maxWidth: .infinity, alignment: .leading)
                     }
                     HStack(spacing: 20) {

--- a/NoCaTra/Components/EntryModule/EntryModuleView.swift
+++ b/NoCaTra/Components/EntryModule/EntryModuleView.swift
@@ -136,13 +136,13 @@ struct EntryModuleView: View {
             // Caption
             caption
                 .font(.caption)
-                .foregroundStyle(.secondary)
+                .foregroundStyle(ColorTheme.secondaryText)
                 .multilineTextAlignment(.center)
         }
         .padding()
         .background(
             RoundedRectangle(cornerRadius: 12)
-                .fill(.background)
+                .fill(ColorTheme.background)
                 .shadow(radius: 2)
         )
     }

--- a/NoCaTra/Views/CalendarTabView/CalendarDailyInfoView.swift
+++ b/NoCaTra/Views/CalendarTabView/CalendarDailyInfoView.swift
@@ -31,13 +31,13 @@ struct CalendarDailyInfoView: View {
                 VStack(alignment: .leading, spacing: 8) {
                     Text("Today's Entries")
                         .font(.subheadline)
-                        .foregroundColor(.secondary)
+                        .foregroundColor(ColorTheme.secondaryText)
                     
                     let entriesForDate = viewModel.entries(for: selectedDate, context: context)
     
                     if entriesForDate.isEmpty {
                         Text("No entries for today")
-                            .foregroundColor(.secondary)
+                            .foregroundColor(ColorTheme.secondaryText)
                             .italic()
                     } else {
                         ForEach(entriesForDate) { entry in
@@ -90,6 +90,6 @@ struct CalendarDailyInfoView: View {
             }
             .frame(maxWidth: .infinity, alignment: .leading)
         }
-        .background(Color(white: 0.95))
+        .background(ColorTheme.background)
     }
 }

--- a/NoCaTra/Views/CalendarTabView/CalendarView.swift
+++ b/NoCaTra/Views/CalendarTabView/CalendarView.swift
@@ -20,7 +20,7 @@ struct CalendarView: View {
             HStack {
                 Button(action: previousMonth) {
                     Image(systemName: "chevron.left")
-                        .foregroundColor(.blue)
+                        .foregroundColor(ColorTheme.primaryGreen)
                 }
                 
                 Text(monthYearString)
@@ -30,7 +30,7 @@ struct CalendarView: View {
                 
                 Button(action: nextMonth) {
                     Image(systemName: "chevron.right")
-                        .foregroundColor(.blue)
+                        .foregroundColor(ColorTheme.primaryGreen)
                 }
             }
             .padding(.horizontal)
@@ -40,7 +40,7 @@ struct CalendarView: View {
                 ForEach(weekdaySymbols, id: \.self) { symbol in
                     Text(symbol)
                         .frame(maxWidth: .infinity)
-                        .foregroundColor(.gray)
+                        .foregroundColor(ColorTheme.secondaryText)
                 }
             }
             
@@ -129,10 +129,10 @@ struct DayView: View {
         Group {
             if isSelected {
                 Circle()
-                    .fill(Color.blue)
+                    .fill(ColorTheme.primaryGreen)
             } else if isToday {
                 Circle()
-                    .stroke(Color.blue, lineWidth: 1)
+                    .stroke(ColorTheme.primaryGreen, lineWidth: 1)
             }
         }
     }

--- a/NoCaTra/Views/UnlockableView.swift
+++ b/NoCaTra/Views/UnlockableView.swift
@@ -31,7 +31,7 @@ struct UnlockableView: View {
                 
                 Text("Toggle entries to unlock or lock them")
                     .font(.caption)
-                    .foregroundColor(.secondary)
+                    .foregroundColor(ColorTheme.secondaryText)
                     .padding()
             }
             .navigationTitle("Unlock Features")


### PR DESCRIPTION
## Summary
- unify color palette with `ColorTheme`
- apply theme colors in calendar view & daily info
- use theme colors for entry modules and unlockable view

## Testing
- `swift test --enable-code-coverage` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6854835ff198832ca5e01fe3dd7e614b