### PR TITLE
Hide locked modules on calendar page

### DIFF
--- a/NoCaTra/Views/CalendarTabView/CalendarDailyInfoView.swift
+++ b/NoCaTra/Views/CalendarTabView/CalendarDailyInfoView.swift
@@ -11,6 +11,7 @@ import SwiftData
 struct CalendarDailyInfoView: View {
     let selectedDate: Date
     @ObservedObject var viewModel: CalendarViewModel
+    @ObservedObject var unlockableViewModel: UnlockableViewModel
     @Environment(\.modelContext) private var context
     
     private let dateFormatter: DateFormatter = {
@@ -33,7 +34,9 @@ struct CalendarDailyInfoView: View {
                         .font(.subheadline)
                         .foregroundColor(.secondary)
                     
-                    let entriesForDate = viewModel.entries(for: selectedDate, context: context)
+                    let entriesForDate = viewModel
+                        .entries(for: selectedDate, context: context)
+                        .filter(isUnlocked)
     
                     if entriesForDate.isEmpty {
                         Text("No entries for today")
@@ -100,5 +103,19 @@ struct CalendarDailyInfoView: View {
             .frame(maxWidth: .infinity, alignment: .leading)
         }
         .background(Color(white: 0.95))
+    }
+
+    private func isUnlocked(_ entry: EntryModule) -> Bool {
+        switch (entry.category, entry.contentType) {
+        case (.food, .diary): return unlockableViewModel.unlockStates[0]
+        case (.food, .plan): return unlockableViewModel.unlockStates[1]
+        case (.food, .rating): return unlockableViewModel.unlockStates[2]
+        case (.exercise, .diary): return unlockableViewModel.unlockStates[3]
+        case (.exercise, .plan): return unlockableViewModel.unlockStates[4]
+        case (.exercise, .rating): return unlockableViewModel.unlockStates[5]
+        case (.mindfulness, .diary): return unlockableViewModel.unlockStates[6]
+        case (.mindfulness, .plan): return unlockableViewModel.unlockStates[7]
+        case (.mindfulness, .rating): return unlockableViewModel.unlockStates[8]
+        }
     }
 }

--- a/NoCaTra/Views/CalendarTabView/CalendarTabView.swift
+++ b/NoCaTra/Views/CalendarTabView/CalendarTabView.swift
@@ -10,18 +10,23 @@ import SwiftUI
 struct CalendarTabView: View {
     @State private var selectedDate = Date()
     @StateObject private var calendarViewModel = CalendarViewModel()
+    @ObservedObject var unlockableViewModel: UnlockableViewModel
     
     var body: some View {
         ScrollView {
             VStack(spacing: 0) {
                 CalendarHeaderView()
                 CalendarView(selectedDate: $selectedDate, calendarViewModel: calendarViewModel)
-                CalendarDailyInfoView(selectedDate: selectedDate, viewModel: calendarViewModel)
+                CalendarDailyInfoView(
+                    selectedDate: selectedDate,
+                    viewModel: calendarViewModel,
+                    unlockableViewModel: unlockableViewModel
+                )
             }
         }
     }
 }
 
 #Preview {
-    CalendarTabView()
+    CalendarTabView(unlockableViewModel: UnlockableViewModel())
 }

--- a/NoCaTra/Views/ContentView.swift
+++ b/NoCaTra/Views/ContentView.swift
@@ -18,7 +18,7 @@ struct ContentView: View {
                 .tag(1)
             
             
-            CalendarTabView()
+            CalendarTabView(unlockableViewModel: unlockableViewModel)
                 .tabItem {
                     Label("Calendar", systemImage: "calendar")
                 }


### PR DESCRIPTION
## Summary
- filter calendar entries based on unlock states
- inject `UnlockableViewModel` into `CalendarTabView` and `CalendarDailyInfoView`
- connect calendar tab to the shared unlockable view model

## Testing
- `swift test -v` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68548b29cdb0832c8e7f7d5864e5db78