### PR TITLE
Add rounded borders to calendar UI

### DIFF
--- a/NoCaTra/Views/CalendarTabView/CalendarHeaderView.swift
+++ b/NoCaTra/Views/CalendarTabView/CalendarHeaderView.swift
@@ -7,12 +7,21 @@
 
 import SwiftUI
 
+/// Displays the heading for the calendar page.
+/// A rounded border is applied so it matches the module style.
+
 struct CalendarHeaderView: View {
     var body: some View {
         Text("Tracker Calendar")
             .font(.title2)
             .fontWeight(.bold)
-            .padding()
+            .padding(8)
+            .frame(maxWidth: .infinity)
+            .background(
+                RoundedRectangle(cornerRadius: 12)
+                    .stroke(ColorTheme.accent, lineWidth: 2)
+            )
+            .padding(.horizontal)
     }
 }
 

--- a/NoCaTra/Views/CalendarTabView/CalendarView.swift
+++ b/NoCaTra/Views/CalendarTabView/CalendarView.swift
@@ -7,6 +7,9 @@
 
 import SwiftUI
 
+/// Visual calendar component used in the calendar page.
+/// Wrapped in a rounded border to match the aesthetic of the modules.
+
 struct CalendarView: View {
     @Binding var selectedDate: Date
     @State private var displayedMonth = Date()
@@ -62,6 +65,11 @@ struct CalendarView: View {
             }
         }
         .padding()
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .stroke(ColorTheme.accent, lineWidth: 2)
+        )
+        .padding(.horizontal)
     }
     
     private var monthYearString: String {


### PR DESCRIPTION
## Summary
- style calendar page with rounded border to match existing module design
- add documentation comments around calendar components

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68548cb8bd28832c92b7b95362823ab4