### PR TITLE
Add Today button to calendar view

### DIFF
--- a/NoCaTra/Views/CalendarTabView/CalendarView.swift
+++ b/NoCaTra/Views/CalendarTabView/CalendarView.swift
@@ -22,16 +22,19 @@ struct CalendarView: View {
                     Image(systemName: "chevron.left")
                         .foregroundColor(.blue)
                 }
-                
+
                 Text(monthYearString)
                     .font(.title2)
                     .fontWeight(.bold)
                     .frame(maxWidth: .infinity)
-                
+
                 Button(action: nextMonth) {
                     Image(systemName: "chevron.right")
                         .foregroundColor(.blue)
                 }
+
+                Button("Today", action: goToToday)
+                    .foregroundColor(.blue)
             }
             .padding(.horizontal)
             
@@ -108,6 +111,12 @@ struct CalendarView: View {
         if let newDate = calendar.date(byAdding: .month, value: 1, to: displayedMonth) {
             displayedMonth = newDate
         }
+    }
+
+    private func goToToday() {
+        let today = Date()
+        displayedMonth = today
+        selectedDate = today
     }
 }
 


### PR DESCRIPTION
## Summary
- add a **Today** button next to the month navigation
- implement `goToToday()` to reset the view to the current day

## Testing
- `swiftc -emit-sil NoCaTra/Views/CalendarTabView/CalendarView.swift` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_68548ec9ced4832ca505548ef593ead6